### PR TITLE
Support Puppetserver 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ module](https://github.com/theforeman/puppet-foreman).
 
 ## Compatibility
 
-Foreman API v2: 1.3 - 2.x
-Puppetserver: 1.x - 6.x
+* Foreman API v2: 1.3 - 2.x
+* Puppetserver: 1.x - 7.x
 
 These scripts have a long history and have basically been unchanged since
 Puppet 2.6, even before Puppetserver existed. Since they haven't dropped code,

--- a/files/enc.rb
+++ b/files/enc.rb
@@ -35,6 +35,27 @@ def puppetuser
   SETTINGS[:puppetuser] || 'puppet'
 end
 
+def fact_extension
+  SETTINGS[:fact_extension] || 'yaml'
+end
+
+def fact_directory
+  data_dir = fact_extension == 'yaml' ? 'yaml' : 'server_data'
+  File.join(puppetdir, data_dir, 'facts')
+end
+
+def fact_file(certname)
+  File.join(fact_directory, "#{certname}.#{fact_extension}")
+end
+
+def fact_files
+  Dir[File.join(fact_directory, "*.#{fact_extension}")]
+end
+
+def certname_from_filename(filename)
+  File.basename(filename, ".#{fact_extension}")
+end
+
 def stat_file(certname)
   FileUtils.mkdir_p "#{puppetdir}/yaml/foreman/"
   "#{puppetdir}/yaml/foreman/#{certname}.yaml"
@@ -93,44 +114,56 @@ rescue LoadError
   end
 end
 
-def empty_values_hash?(facts_file)
-  facts = File.read(facts_file)
-  puppet_facts = YAML::load(facts.gsub(/\!ruby\/object.*$/,''))
+def parse_file(filename, mac_address_workaround = false)
+  case File.extname(filename)
+  when '.yaml'
+    data = File.read(filename)
+    quote_macs!(data) if mac_address_workaround && YAML.load('22:22:22:22:22:22').is_a?(Integer)
+    YAML.load(data.gsub(/\!ruby\/object.*$/,''))
+  when '.json'
+    JSON.parse(File.read(filename))
+  else
+    raise "Unknown extension for file '#{filename}'"
+  end
+end
 
+def empty_values_hash?(facts_file)
+  puppet_facts = parse_file(facts_file)
   puppet_facts['values'].empty?
 end
 
 def process_host_facts(certname)
-    f = "#{puppetdir}/yaml/facts/#{certname}.yaml"
-    if File.size(f) != 0
-      if empty_values_hash?(f)
-        puts "Empty values hash in fact file #{f}, not uploading"
-        return 0
-      end
-
-      req = generate_fact_request(certname, f)
-      begin
-        upload_facts(certname, req) if req
-        return 0
-      rescue => e
-        $stderr.puts "During fact upload occurred an exception: #{e}"
-        return 1
-      end
-    else
-      $stderr.puts "Fact file #{f} does not contain any facts"
-      return 2
+  f = fact_file(certname)
+  if File.size(f) != 0
+    if empty_values_hash?(f)
+      puts "Empty values hash in fact file #{f}, not uploading"
+      return 0
     end
+
+    req = generate_fact_request(certname, f)
+    begin
+      upload_facts(certname, req) if req
+      return 0
+    rescue => e
+      $stderr.puts "During fact upload occurred an exception: #{e}"
+      return 1
+    end
+  else
+    $stderr.puts "Fact file #{f} does not contain any facts"
+    return 2
+  end
 end
 
 def process_all_facts(http_requests)
-  Dir["#{puppetdir}/yaml/facts/*.yaml"].each do |f|
-    certname = File.basename(f, ".yaml")
-    # Skip empty host fact yaml files
+  fact_files.each do |f|
+    # Skip empty host fact files
     if File.size(f) != 0
       if empty_values_hash?(f)
         puts "Empty values hash in fact file #{f}, not uploading"
         next
       end
+
+      certname = certname_from_filename(f)
       req = generate_fact_request(certname, f)
       if http_requests
         http_requests << [certname, req]
@@ -150,10 +183,7 @@ def quote_macs! facts
 end
 
 def build_body(certname,filename)
-  # Strip the Puppet:: ruby objects and keep the plain hash
-  facts        = File.read(filename)
-  quote_macs! facts if YAML.load('22:22:22:22:22:22').is_a? Integer
-  puppet_facts = YAML::load(facts.gsub(/\!ruby\/object.*$/,''))
+  puppet_facts = parse_file(filename, true)
   hostname     = puppet_facts['values']['fqdn'] || certname
 
   # if there is no environment in facts
@@ -161,8 +191,8 @@ def build_body(certname,filename)
   unless puppet_facts['values'].key?('environment') || puppet_facts['values'].key?('agent_specified_environment')
     node_filename = filename.sub('/facts/', '/node/')
     if File.exist?(node_filename)
-      node_yaml = File.read(node_filename)
-      node_data = YAML::load(node_yaml.gsub(/\!ruby\/object.*$/,''))
+      node_data = parse_file(node_filename)
+
       if node_data.key?('environment')
         puppet_facts['values']['environment'] = node_data['environment']
       end
@@ -301,19 +331,21 @@ def watch_and_send_facts(parallel)
 
   inotify = Inotify.new
 
+  fact_dir = fact_directory
+
   # actually we need only MOVED_TO events because puppet uses File.rename after tmp file created and flushed.
   # see lib/puppet/util.rb near line 469
-  inotify.add_watch("#{puppetdir}/yaml/facts", Inotify::CREATE | Inotify::MOVED_TO )
+  inotify.add_watch(fact_dir, Inotify::CREATE | Inotify::MOVED_TO )
 
-  yamls = Dir["#{puppetdir}/yaml/facts/*.yaml"]
+  files = fact_files
 
-  if yamls.length > inotify_limit
-    puts "Looks like your inotify watch limit is #{inotify_limit} but you are asking to watch at least #{yamls.length} fact files."
+  if files.length > inotify_limit
+    puts "Looks like your inotify watch limit is #{inotify_limit} but you are asking to watch at least #{files.length} fact files."
     puts "Increase the watch limit via the system tunable fs.inotify.max_user_watches, exiting."
     exit 2
   end
 
-  yamls.each do |f|
+  files.each do |f|
     begin
       watch_descriptors[inotify.add_watch(f, Inotify::CLOSE_WRITE)] = f
     end
@@ -323,14 +355,14 @@ def watch_and_send_facts(parallel)
     fn = watch_descriptors[ev.wd]
     add_watch = false
 
-    if !fn
+    unless fn
       # inotify returns basename for renamed file as ev.name
       # but we need full path
-      fn = "#{puppetdir}/yaml/facts/#{ev.name}"
+      fn = File.join(fact_dir, ev.name)
       add_watch = true
     end
 
-    if File.extname(fn) != ".yaml"
+    if File.extname(fn) != ".#{fact_extension}"
       next
     end
 
@@ -339,7 +371,7 @@ def watch_and_send_facts(parallel)
     end
 
     if fn
-      certname = File.basename(fn, ".yaml")
+      certname = certname_from_filename(fn)
       req = generate_fact_request certname, fn
       if parallel
         pending << [certname,req]
@@ -404,7 +436,7 @@ if __FILE__ == $0 then
           # if you use this option below, make sure that you don't send facts to foreman via the rake task or push facts alternatives.
           #
           if SETTINGS[:facts]
-            req = generate_fact_request certname, "#{puppetdir}/yaml/facts/#{certname}.yaml"
+            req = generate_fact_request(certname, fact_file(certname))
             upload_facts(certname, req)
           end
 

--- a/files/enc.rb
+++ b/files/enc.rb
@@ -113,11 +113,11 @@ def process_host_facts(certname)
         upload_facts(certname, req) if req
         return 0
       rescue => e
-        $stderr.puts "During fact upload occured an exception: #{e}"
+        $stderr.puts "During fact upload occurred an exception: #{e}"
         return 1
       end
     else
-      $stderr.puts "Fact file #{f} does not contain any fact"
+      $stderr.puts "Fact file #{f} does not contain any facts"
       return 2
     end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,9 @@
 #   Whether to configure the ENC to send facts to Foreman
 # @param puppet_home
 #   The Puppet home where the YAML files with facts live. Used for the ENC script
+# @param enc_fact_extension
+#   The fact extension to use. Support for json was added in Puppetserver
+#   6.20.0. Puppetserver < 7 defaults to yaml, >= 7 defaults to json.
 #
 # @param reports
 #   Whether to enable the report processor
@@ -38,6 +41,7 @@ class puppetserver_foreman (
   Boolean $enc = true,
   Integer[0] $enc_timeout = 60,
   Boolean $enc_upload_facts = true,
+  Enum['yaml', 'json'] $enc_fact_extension = $puppetserver_foreman::params::enc_fact_extension,
   Stdlib::Absolutepath $puppet_home = $puppetserver_foreman::params::puppet_home,
   String $puppet_user = 'puppet',
   String $puppet_group = 'puppet',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,4 +50,6 @@ class puppetserver_foreman::params {
   # Used to authenticate to Foreman, required if require_ssl_puppetmasters is enabled
   $client_ssl_cert = "${puppet_ssldir}/certs/${lower_fqdn}.pem"
   $client_ssl_key  = "${puppet_ssldir}/private_keys/${lower_fqdn}.pem"
+
+  $enc_fact_extension = bool2str(versioncmp($facts['puppetversion'], '7.0') >= 0, 'json', 'yaml')
 }

--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.8 < 7.0.0"
+      "version_requirement": ">= 5.5.8 < 8.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -47,8 +47,20 @@ describe 'puppetserver_foreman' do
 
       let(:json_package) { facts[:os]['family'] == 'Debian' ? 'ruby-json' : 'rubygem-json' }
 
+      let(:fact_extension) { facts[:puppetversion].to_i >= 7 ? 'json' : 'yaml' }
+
       describe 'without custom parameters' do
         it { should contain_class('puppetserver_foreman::params') }
+        it do
+          should contain_class('puppetserver_foreman')
+            .with_enc_fact_extension(fact_extension)
+            .with_puppet_home(var_dir)
+            .with_puppet_basedir("#{site_ruby}/puppet")
+            .with_puppet_etcdir(etc_dir)
+            .with_ssl_ca(%r{^#{ssl_dir}/.+\.pem$})
+            .with_ssl_cert(%r{^#{ssl_dir}/.+\.pem$})
+            .with_ssl_key(%r{^#{ssl_dir}/.+\.pem$})
+        end
 
         it 'should set up reports' do
           should contain_exec('Create Puppet Reports dir')
@@ -113,6 +125,7 @@ describe 'puppetserver_foreman' do
             ":puppetdir: \"#{var_dir}\"",
             ':puppetuser: "puppet"',
             ':facts: true',
+            ":fact_extension: \"#{fact_extension}\"",
             ':timeout: 60',
             ':report_timeout: 60',
             ':threads: null',

--- a/templates/puppet.yaml.erb
+++ b/templates/puppet.yaml.erb
@@ -6,6 +6,7 @@
 :puppetdir: "<%= @puppet_home %>"
 :puppetuser: "<%= @puppet_user %>"
 :facts: <%= @enc_upload_facts %>
+:fact_extension: "<%= @enc_fact_extension %>"
 :timeout: <%= @enc_timeout %>
 :report_timeout: <%= @reports_timeout %>
 :threads: null


### PR DESCRIPTION
In Puppetserver 6.20.0 support was added for a JSON fact cache and Puppetserver 7 defaults to JSON. JSON is faster than YAML and doesn't have quirks like the mac address which is parsed different depending on Ruby versions.

See https://tickets.puppetlabs.com/browse/PUP-10656 for the change.