### PR TITLE
Fix beaker task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       puppet_major_versions: ${{ steps.get_outputs.outputs.puppet_major_versions }}
       puppet_unit_test_matrix: ${{ steps.get_outputs.outputs.puppet_unit_test_matrix }}
     env:
-      BUNDLE_WITHOUT: development:release
+      BUNDLE_WITHOUT: development:system_tests:release
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby

--- a/Gemfile
+++ b/Gemfile
@@ -13,11 +13,12 @@ gem 'puppet-lint-param-docs', '>= 1.3.0', {"groups"=>["test"]}
 gem 'puppet-lint-spaceship_operator_without_tag-check', {"groups"=>["test"]}
 gem 'puppet-lint-strict_indent-check', {"groups"=>["test"]}
 gem 'puppet-lint-undef_in_function-check', {"groups"=>["test"]}
-gem 'voxpupuli-test', '~> 1.4'
+gem 'voxpupuli-test', '~> 1.4', {"groups"=>["test"]}
 gem 'github_changelog_generator', '>= 1.15.0', {"groups"=>["development"]}
 gem 'puppet_metadata', '~> 0.3'
 gem 'puppet-blacksmith', '>= 6.0.0', {"groups"=>["development"]}
-gem 'voxpupuli-acceptance', '~> 0.3', {"groups"=>["system_tests"]}
+gem 'voxpupuli-acceptance', '~> 1.0', {"groups"=>["system_tests"]}
+gem 'puppetlabs_spec_helper', {"groups"=>["system_tests"]}
 gem 'webmock', '~> 2.0'
 gem 'oauth'
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,26 @@
 # This file is managed centrally by modulesync
 #   https://github.com/theforeman/foreman-installer-modulesync
 
-require 'voxpupuli/test/rake'
+# Attempt to load voxupuli-test (which pulls in puppetlabs_spec_helper),
+# otherwise attempt to load it directly.
+begin
+  require 'voxpupuli/test/rake'
+rescue LoadError
+  begin
+    require 'puppetlabs_spec_helper/rake_tasks'
+  rescue LoadError
+  end
+end
 
-# We use fixtures in our modules, which is not the default
-task :beaker => 'spec_prep'
+# load optional tasks for acceptance
+# only available if gem group releases is installed
+begin
+  require 'voxpupuli/acceptance/rake'
+rescue LoadError
+else
+  # We use fixtures in our modules, which is not the default
+  task :beaker => 'spec_prep'
+end
 
 # blacksmith isn't always present, e.g. on Travis with --without development
 begin


### PR DESCRIPTION
In puppetlabs_spec_helper 4.x the beaker task was removed. This loads it from voxpupuli-aceptance.