### PR TITLE
Correct assertion to reflect ensure_packages new default

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -107,7 +107,7 @@ describe 'puppetserver_foreman' do
         end
 
         it 'should install json package' do
-          should contain_package(json_package).with_ensure('present')
+          should contain_package(json_package).with_ensure('installed')
         end
 
         it 'should create puppet.yaml' do


### PR DESCRIPTION
In puppetlabs/stdlib 8 this was changed from present to installed.