### PR TITLE
Add report_retry_limit setting

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,8 @@
 #   Whether to enable the report processor
 # @param reports_timeout
 #   The timeout to use on HTTP calls in the report processor
+# @param report_retry_limit
+#   The number of times to retry HTTP calls in the report processor
 # @param puppet_basedir
 #   The directory used to install the report processor to
 class puppetserver_foreman (
@@ -49,6 +51,7 @@ class puppetserver_foreman (
   Stdlib::Absolutepath $puppet_etcdir = $puppetserver_foreman::params::puppet_etcdir,
   Boolean $reports = true,
   Integer[0] $reports_timeout = 60,
+  Integer[0] $report_retry_limit = 1,
   Variant[Enum[''], Stdlib::Absolutepath] $ssl_ca = $puppetserver_foreman::params::client_ssl_ca,
   Variant[Enum[''], Stdlib::Absolutepath] $ssl_cert = $puppetserver_foreman::params::client_ssl_cert,
   Variant[Enum[''], Stdlib::Absolutepath] $ssl_key = $puppetserver_foreman::params::client_ssl_key,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -128,6 +128,7 @@ describe 'puppetserver_foreman' do
             ":fact_extension: \"#{fact_extension}\"",
             ':timeout: 60',
             ':report_timeout: 60',
+            ':report_retry_limit: 1',
             ':threads: null',
           ])
         end

--- a/templates/puppet.yaml.erb
+++ b/templates/puppet.yaml.erb
@@ -9,4 +9,5 @@
 :fact_extension: "<%= @enc_fact_extension %>"
 :timeout: <%= @enc_timeout %>
 :report_timeout: <%= @reports_timeout %>
+:report_retry_limit: <%= @report_retry_limit %>
 :threads: null


### PR DESCRIPTION
Add `report_retry_limit` setting to be able to override the default of 1 as needed in the report processor (match current default if not set)

ref: https://github.com/theforeman/puppet-puppetserver_foreman/blob/6fbe210e61c95e0aed4a4052d11daac693912e46/files/report.rb#L40
