### PR TITLE
Simplify the report processor

### DIFF
--- a/files/report.rb
+++ b/files/report.rb
@@ -126,7 +126,7 @@ Puppet::Reports.register_report(:foreman) do
       report_status["failed"] += 1
     end
     # fix for Puppet non-resource errors (i.e. failed catalog fetches before falling back to cache)
-    report_status["failed"] += report.logs.find_all {|l| l.source =~ /Puppet$/ && l.level.to_s == 'err' }.count
+    report_status["failed"] += report.logs.count {|l| l.source =~ /Puppet$/ && l.level.to_s == 'err' }
 
     return report_status
   end

--- a/files/report.rb
+++ b/files/report.rb
@@ -37,7 +37,7 @@ Puppet::Reports.register_report(:foreman) do
 
   def process
     # Default retry limit is 1.
-    retry_limit = SETTINGS[:report_retry_limit] ? SETTINGS[:report_retry_limit] : 1
+    retry_limit = SETTINGS.fetch(:report_retry_limit, 1)
     tries = 0
     begin
       # check for report metrics

--- a/files/report.rb
+++ b/files/report.rb
@@ -144,11 +144,17 @@ Puppet::Reports.register_report(:foreman) do
       next if log.message =~ /^Finished catalog run in \d+.\d+ seconds$/
 
       # Match Foreman's slightly odd API format...
-      l = { 'log' => { 'sources' => {}, 'messages' => {} } }
-      l['log']['level'] = log.level.to_s
-      l['log']['messages']['message'] = log.message
-      l['log']['sources']['source'] = log.source
-      h << l
+      h << {
+        'log' => {
+          'level' => log.level.to_s,
+          'sources' => {
+            'source' => log.source,
+          },
+          'messages' => {
+            'message' => log.message,
+          },
+        },
+      }
     end
     return h
   end

--- a/files/report.rb
+++ b/files/report.rb
@@ -78,15 +78,14 @@ Puppet::Reports.register_report(:foreman) do
   end
 
   def generate_report
-    report = {}
-    report['host'] = self.host
-    # Time.to_s behaves differently in 1.8 / 1.9 so we explicity set the 1.9 format
-    report['reported_at'] = self.time.utc.strftime("%Y-%m-%d %H:%M:%S UTC")
-    report['status'] = metrics_to_hash(self)
-    report['metrics'] = m2h(self.metrics)
-    report['logs'] = logs_to_array(self.logs)
-
-    report
+    {
+      'host' => self.host,
+      # Time.to_s behaves differently in 1.8 / 1.9 so we explicity set the 1.9 format
+      'reported_at' => self.time.utc.strftime("%Y-%m-%d %H:%M:%S UTC"),
+      'status' => metrics_to_hash(self),
+      'metrics' => m2h(self.metrics),
+      'logs' => logs_to_array(self.logs),
+    }
   end
 
   private

--- a/files/report.rb
+++ b/files/report.rb
@@ -99,9 +99,21 @@ Puppet::Reports.register_report(:foreman) do
 
     # find our metric values
     METRIC.each do |m|
-      h=translate_metrics_to26(m)
-      mv = metrics[h[:type]]
-      report_status[m] = mv[h[:name].to_sym] + mv[h[:name].to_s] rescue nil
+      case m
+      when "applied"
+        mv = metrics["changes"]
+        name = "total"
+      when "failed_restarts"
+        mv = metrics["resources"]
+        name = "failed_to_restart"
+      when "pending"
+        mv = metrics["events"]
+        name = "noop"
+      else
+        mv = metrics["resources"]
+        name = m
+      end
+      report_status[m] = mv[name.to_sym] + mv[name.to_s] rescue nil
       report_status[m] ||= 0
     end
 
@@ -152,22 +164,6 @@ Puppet::Reports.register_report(:foreman) do
       }
     end
     return h
-  end
-
-  # The metrics layout has changed in Puppet 2.6.x release,
-  # this method attempts to align the bit value metrics and the new name scheme in 2.6.x
-  # returns a hash of { :type => "metric type", :name => "metric_name"}
-  def translate_metrics_to26 metric
-    case metric
-    when "applied"
-      { :type => "changes", :name => "total"}
-    when "failed_restarts"
-      { :type => "resources", :name => "failed_to_restart"}
-    when "pending"
-      { :type => "events", :name => "noop" }
-    else
-      { :type => "resources", :name => metric}
-    end
   end
 
   def foreman_url

--- a/files/report.rb
+++ b/files/report.rb
@@ -133,12 +133,9 @@ Puppet::Reports.register_report(:foreman) do
   end
 
   def m2h metrics
-    h = {}
-    metrics.each do |title, mtype|
-      h[mtype.name] ||= {}
-      mtype.values.each{|m| h[mtype.name].merge!({m[0].to_s => m[2]})}
+    metrics.to_h do |title, mtype|
+      [title, mtype.values.to_h { |name, _label, value| [name, value] }]
     end
-    return h
   end
 
   def logs_to_array logs


### PR DESCRIPTION
This drops a lot of old legacy code that was used in the Puppet < 2.6 days. Those days are far behind us and this simplifies the processor a lot. It still doesn't take advantage of fields added in "recent" versions.