### PR TITLE
Fixes #35684 - Drop Applied catalog lines

### DIFF
--- a/files/report.rb
+++ b/files/report.rb
@@ -141,7 +141,7 @@ Puppet::Reports.register_report(:foreman) do
       next if log.level == :debug
 
       # skipping catalog summary run messages, we dont want them in Foreman's db
-      next if log.message =~ /^Finished catalog run in \d+.\d+ seconds$/
+      next if log.message =~ /^(Finished catalog run|Applied catalog) in \d+.\d+ seconds$/
 
       # Match Foreman's slightly odd API format...
       l = { 'log' => { 'sources' => {}, 'messages' => {} } }

--- a/spec/static_fixtures/report-format-6.json
+++ b/spec/static_fixtures/report-format-6.json
@@ -210,17 +210,6 @@
         },
         "level": "notice"
       }
-    },
-    {
-      "log": {
-        "sources": {
-          "source": "//slave01.rackspace.theforeman.org/Puppet"
-        },
-        "messages": {
-          "message": "Applied catalog in 14.26 seconds"
-        },
-        "level": "notice"
-      }
     }
   ]
 }


### PR DESCRIPTION
In the past we dropped the line which stated how log catalog application took since there's a metric for this. This was done by matching the content, but the content changed somewhere between report version 3 and 6.

This saves a lot of redundant messages in the Foreman database. An uneventful report will now have no messages at all.