### PR TITLE
Refs #35833 - Revert "Fixes #35684 - Drop Applied catalog lines"

### DIFF
--- a/files/report.rb
+++ b/files/report.rb
@@ -141,7 +141,7 @@ Puppet::Reports.register_report(:foreman) do
       next if log.level == :debug
 
       # skipping catalog summary run messages, we dont want them in Foreman's db
-      next if log.message =~ /^(Finished catalog run|Applied catalog) in \d+.\d+ seconds$/
+      next if log.message =~ /^Finished catalog run in \d+.\d+ seconds$/
 
       # Match Foreman's slightly odd API format...
       l = { 'log' => { 'sources' => {}, 'messages' => {} } }

--- a/spec/static_fixtures/report-format-6.json
+++ b/spec/static_fixtures/report-format-6.json
@@ -210,6 +210,17 @@
         },
         "level": "notice"
       }
+    },
+    {
+      "log": {
+        "sources": {
+          "source": "//slave01.rackspace.theforeman.org/Puppet"
+        },
+        "messages": {
+          "message": "Applied catalog in 14.26 seconds"
+        },
+        "level": "notice"
+      }
     }
   ]
 }


### PR DESCRIPTION
This reverts commit 4f65dd51a251badfb7bb7710542b9370d9cc6d18. It's problematic because Foreman can't identify reports as Puppet reports if there are no entries. Until Foreman has an API where it can be identified as Puppet even if there are no logs we should continue sending it.

I've also considered sending a static string so Foreman can deduplicate the strings.