### PR TITLE
Fixes #36573 - Reuse foreman_url answer from foreman_proxy module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,8 @@ vendor/
 .ruby-*
 
 ## rspec
-spec/fixtures/
+spec/fixtures/manifests
+spec/fixtures/modules
 junit/
 
 ## Puppet module

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,7 +2,7 @@
 # @api private
 class puppetserver_foreman::params {
   $lower_fqdn = downcase($facts['networking']['fqdn'])
-  $foreman_url = "https://${lower_fqdn}"
+  $foreman_url = lookup('foreman_proxy::foreman_base_url') |$key| { "https://${lower_fqdn}" }
 
   if fact('aio_agent_version') =~ String[1] {
     $puppet_basedir = '/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -154,6 +154,12 @@ describe 'puppetserver_foreman' do
           should_not contain_file("#{etc_dir}/node.rb")
         end
       end
+
+      describe 'with foreman_url via Hiera' do
+        let(:hiera_config) { 'spec/fixtures/hiera/hiera.yaml' }
+
+        it { should contain_class('puppetserver_foreman').with_foreman_url('https://hiera-foreman.example.com') }
+      end
     end
   end
 end

--- a/spec/fixtures/hiera/hiera.yaml
+++ b/spec/fixtures/hiera/hiera.yaml
@@ -1,0 +1,8 @@
+---
+version: 5
+
+hierarchy:
+  - name: 'test'
+    data_hash: 'yaml_data'
+    datadir: '.'
+    path: 'test.yaml'

--- a/spec/fixtures/hiera/test.yaml
+++ b/spec/fixtures/hiera/test.yaml
@@ -1,0 +1,2 @@
+---
+foreman_proxy::foreman_base_url: 'https://hiera-foreman.example.com'


### PR DESCRIPTION
Rather than requiring the user to specify it twice, this prefers the Hiera answer from the foreman_proxy module with the older value as a fallback. It's also a default, so users providing it explicitly won't be affected.