### PR TITLE
Make TLS authentication to foreman optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,8 @@
 #   The number of times to retry HTTP calls in the report processor
 # @param puppet_basedir
 #   The directory used to install the report processor to
+# @param use_client_tls_certs
+#   Enable client TLS authentication to foreman
 class puppetserver_foreman (
   Stdlib::HTTPUrl $foreman_url = $puppetserver_foreman::params::foreman_url,
   Boolean $enc = true,
@@ -55,6 +57,7 @@ class puppetserver_foreman (
   Variant[Enum[''], Stdlib::Absolutepath] $ssl_ca = $puppetserver_foreman::params::client_ssl_ca,
   Variant[Enum[''], Stdlib::Absolutepath] $ssl_cert = $puppetserver_foreman::params::client_ssl_cert,
   Variant[Enum[''], Stdlib::Absolutepath] $ssl_key = $puppetserver_foreman::params::client_ssl_key,
+  Boolean $use_client_tls_certs = true,
 ) inherits puppetserver_foreman::params {
   case $facts['os']['family'] {
     'Debian': { $json_package = 'ruby-json' }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -134,6 +134,14 @@ describe 'puppetserver_foreman' do
         end
       end
 
+      describe 'without TLS client authenticatio' do
+        let :params do
+          { use_client_tls_certs: false }
+        end
+
+        it { is_expected.to contain_file("#{etc_dir}/foreman.yaml").without_content(%r{:ssl_(cert|key):}) }
+      end
+
       describe 'without reports' do
         let :params do
           { reports: false }

--- a/templates/puppet.yaml.erb
+++ b/templates/puppet.yaml.erb
@@ -1,8 +1,10 @@
 ---
 :url: "<%= @foreman_url %>"
 :ssl_ca: "<%= @ssl_ca %>"
+<% if @use_client_tls_certs -%>
 :ssl_cert: "<%= @ssl_cert %>"
 :ssl_key: "<%= @ssl_key %>"
+<% end -%>
 :puppetdir: "<%= @puppet_home %>"
 :puppetuser: "<%= @puppet_user %>"
 :facts: <%= @enc_upload_facts %>


### PR DESCRIPTION
I hacked this for a customer some time ago. The customer has multiple Puppet CAs and the foreman Web UI uses a certificate from a third CA. We had to disable TLS client authentication to get the puppetserver->foreman connection working.