### PR TITLE
enc.rb: Switch from legacy to structured facts

### DIFF
--- a/files/enc.rb
+++ b/files/enc.rb
@@ -202,7 +202,7 @@ def build_body(certname,filename)
 
   begin
     require 'facter'
-    puppet_facts['values']['puppetmaster_fqdn'] = Facter.value(:fqdn).to_s
+    puppet_facts['values']['puppetmaster_fqdn'] = Facter.value('networking.fqdn').to_s
   rescue LoadError
     puppet_facts['values']['puppetmaster_fqdn'] = `hostname -f`.strip
   end


### PR DESCRIPTION
networking.fqdn is the successor. Manual verification:

```
irb(main):001:0> require 'facter'
=> true
irb(main):002:0> puts Facter.value('networking.fqdn')
puppet.local
=> nil
irb(main):003:0>
```