### PR TITLE
Legacy MAC address quoting workaround removed

### DIFF
--- a/files/enc.rb
+++ b/files/enc.rb
@@ -115,11 +115,10 @@ rescue LoadError
   end
 end
 
-def parse_file(filename, mac_address_workaround = false)
+def parse_file(filename)
   case File.extname(filename)
   when '.yaml'
     data = File.read(filename)
-    quote_macs!(data) if mac_address_workaround && YAML.safe_load('22:22:22:22:22:22').is_a?(Integer)
     YAML.safe_load(data.gsub(/\!ruby\/object.*$/,''), permitted_classes: [Symbol, Time])
   when '.json'
     JSON.parse(File.read(filename))
@@ -177,14 +176,8 @@ def process_all_facts(http_requests)
   end
 end
 
-def quote_macs! facts
-  # Adds single quotes to all unquoted mac addresses in the raw yaml fact string
-  # if they might otherwise be interpreted as base60 ints
-  facts.gsub!(/: ([0-5][0-9](:[0-5][0-9]){5})$/,": '\\1'")
-end
-
 def build_body(certname,filename)
-  puppet_facts = parse_file(filename, true)
+  puppet_facts = parse_file(filename)
   hostname     = puppet_facts['values']['fqdn'] || certname
 
   # if there is no environment in facts

--- a/spec/unit/enc_spec.rb
+++ b/spec/unit/enc_spec.rb
@@ -64,33 +64,4 @@ describe 'foreman_external_node' do
     expect(hash['name']).to eql 'fake.host.fqdn.com'
     expect(hash['facts']).to be_a(Hash)
   end
-
-  describe 'quote_macs!' do
-    it 'quotes macs that need quoting' do
-      yaml = "---\n  macaddress: 52:54:00:44:49:56\n"
-      enc.quote_macs! yaml
-      expect(yaml).to eql "---\n  macaddress: '52:54:00:44:49:56'\n"
-    end
-
-    it "doesn't modify quoted macs" do
-      yaml = "---\n  macaddress: '52:54:00:44:49:56'\n"
-      result = yaml.dup
-      enc.quote_macs! result
-      expect(yaml).to eql result
-    end
-
-    it 'only looks for mac addresses at the end of lines' do
-      yaml = "---\n  foo: 52:54:00:44:49:56 isn't something we're going to modify\n"
-      result = yaml.dup
-      enc.quote_macs! result
-      expect(yaml).to eql result
-    end
-
-    it 'ignores mac addresses that couldn\'t be interpreted as base 60' do
-      yaml = "---\n  macaddress: 52:54:FF:44:49:56\n"
-      result = yaml.dup
-      enc.quote_macs! result
-      expect(yaml).to eql result
-    end
-  end
 end


### PR DESCRIPTION
This problem was fixed in Puppet 6.19, and the module only claims
support for Puppet 7+.

See https://tickets.puppetlabs.com/browse/PUP-9505
