### PR TITLE
Use better Ruby methods to transform items

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,5 @@ module](https://github.com/theforeman/puppet-foreman).
 * Foreman API v2: 1.3 - 2.x
 * Puppetserver: 1.x - 7.x
 
-These scripts have a long history and have basically been unchanged since
-Puppet 2.6, even before Puppetserver existed. Since they haven't dropped code,
-they probably still work.
+These scripts have a long history and have basically been unchanged since Puppet 2.6, even before Puppetserver existed.
+They have been adopted to leverage some more modern Ruby methods and require at least Ruby 2.7, but can probably still handle old reports.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ module](https://github.com/theforeman/puppet-foreman).
 
 ## Compatibility
 
-* Foreman API v2: 1.3 - 2.x
+* Foreman API v2: 1.3 - 3.x
 * Puppetserver: 1.x - 7.x
 
 These scripts have a long history and have basically been unchanged since Puppet 2.6, even before Puppetserver existed.

--- a/files/report.rb
+++ b/files/report.rb
@@ -132,14 +132,13 @@ Puppet::Reports.register_report(:foreman) do
   end
 
   def m2h metrics
-    metrics.to_h do |title, mtype|
-      [title, mtype.values.to_h { |name, _label, value| [name, value] }]
+    metrics.transform_values do |mtype|
+      mtype.values.to_h { |name, _label, value| [name, value] }
     end
   end
 
   def logs_to_array logs
-    h = []
-    logs.each do |log|
+    logs.filter_map do |log|
       # skipping debug messages, we dont want them in Foreman's db
       next if log.level == :debug
 
@@ -147,7 +146,7 @@ Puppet::Reports.register_report(:foreman) do
       next if log.message =~ /^Finished catalog run in \d+.\d+ seconds$/
 
       # Match Foreman's slightly odd API format...
-      h << {
+      {
         'log' => {
           'level' => log.level.to_s,
           'sources' => {
@@ -159,7 +158,6 @@ Puppet::Reports.register_report(:foreman) do
         },
       }
     end
-    return h
   end
 
   def foreman_url


### PR DESCRIPTION
The use of transform_values instead of to_h was suggesed by RuboCop. filter_map was introduced in Ruby 2.7 and allows mapping an array to another array while also skipping unwanted items.