### PR TITLE
puppet/systemd: Allow 7.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,7 @@
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 8.2.0 < 9.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
In https://github.com/theforeman/puppet-puppetserver_foreman/pull/52 we added a dependency to puppet/systemd. After some digging around we identified https://github.com/voxpupuli/puppet-systemd/pull/433 which is probably the newest requirement we have. That means we don't need to depend on current latest (8.2.0) version of the module, 7.0.0 and newer are fine.