### PR TITLE
do not swallow failures when sending POST request to foreman

### DIFF
--- a/files/report.rb
+++ b/files/report.rb
@@ -67,6 +67,9 @@ Puppet::Reports.register_report(:foreman) do
       req.content_type = 'application/json'
       req.body         = {'config_report' => generate_report}.to_json
       response = http.request(req)
+      unless response.is_a?(Net::HTTPSuccess)
+        raise Puppet::Error, "HTTP request failed with code: #{response.code} body: #{response.body}"
+      end
     rescue Exception => e
       if (tries += 1) < retry_limit
         Puppet.err "Could not send report to Foreman at #{foreman_url}/api/config_reports (attempt #{tries}/#{retry_limit}). Retrying... Stacktrace: #{e}\n#{e.backtrace}"


### PR DESCRIPTION
any HTTP response with a status code in the 2xx range (e.g., 200 OK, 201 Created, 204 No Content) will be considered a success