### PR TITLE
[report.rb] Skip unnecessary reports strings

### DIFF
--- a/files/report.rb
+++ b/files/report.rb
@@ -146,8 +146,12 @@ Puppet::Reports.register_report(:foreman) do
       # skipping debug messages, we dont want them in Foreman's db
       next if log.level == :debug
 
+      # skipping Puppet 7/8 messages
+      next if log.message =~ /^Requesting catalog from .+$/
+      next if log.message =~ /^Catalog compiled by .+$/
+
       # skipping catalog summary run messages, we dont want them in Foreman's db
-      next if log.message =~ /^Finished catalog run in \d+.\d+ seconds$/
+      next if log.message =~ /^(Finished catalog run|Applied catalog) in \d+.\d+ seconds$/
 
       # Match Foreman's slightly odd API format...
       h << {

--- a/spec/static_fixtures/report-format-6.json
+++ b/spec/static_fixtures/report-format-6.json
@@ -210,17 +210,6 @@
         },
         "level": "notice"
       }
-    },
-    {
-      "log": {
-        "sources": {
-          "source": "//slave01.rackspace.theforeman.org/Puppet"
-        },
-        "messages": {
-          "message": "Applied catalog in 14.26 seconds"
-        },
-        "level": "notice"
-      }
     }
   ]
 }

--- a/spec/static_fixtures/report-format-6.yaml
+++ b/spec/static_fixtures/report-format-6.yaml
@@ -298,15 +298,6 @@ logs:
   time: '2017-06-28T17:28:27.282770457+00:00'
   file: "/etc/puppetlabs/code/environments/production/modules/ntp/manifests/service.pp"
   line: 6
-- !ruby/object:Puppet::Util::Log
-  level: :notice
-  message: Applied catalog in 14.26 seconds
-  source: "//slave01.rackspace.theforeman.org/Puppet"
-  tags:
-  - notice
-  time: '2017-06-28T17:28:31.534448086+00:00'
-  file:
-  line:
 catalog_uuid: e8c2c0aa-6648-4423-b4c1-a1b2b3d19653
 environment: production
 configuration_version: 1498670892


### PR DESCRIPTION
Fixes https://github.com/theforeman/puppet-puppetserver_foreman/issues/72

After this small fix no "empty" reports appears in Foreman

<img width="1452" height="501" alt="13" src="https://github.com/user-attachments/assets/2255d26e-fa68-4cf9-8bfd-479a8d969525" />

<img width="1645" height="259" alt="14" src="https://github.com/user-attachments/assets/2a2971cc-af8f-42b4-8327-9a1779df1bdc" />
